### PR TITLE
Remove casual user guideline from instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,0 @@
-# Copilot Instructions
-
-## Project Guidelines
-- User is casually conversational and refers to the assistant as 'bro'.


### PR DESCRIPTION
Deleted the section in copilot-instructions.md that described the user's conversational style and reference to the assistant as 'bro'.